### PR TITLE
Update package versions for Scalar.AspNetCore and SonarAnalyzer.CSharp

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,8 +31,8 @@
     <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.13.1" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0" />
     <PackageVersion Include="Refit.Newtonsoft.Json" Version="8.0.0" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.0.18" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.13.0.120203" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.6.1" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.14.0.120626" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.6.6" />
     <!-- Testing -->


### PR DESCRIPTION
This pull request updates package versions in the `Directory.Packages.props` file to ensure compatibility and leverage the latest features and fixes.

Dependency updates:

* Updated the `Scalar.AspNetCore` package version from `2.0.18` to `2.6.1`.
* Updated the `SonarAnalyzer.CSharp` package version from `10.13.0.120203` to `10.14.0.120626`.